### PR TITLE
Connect error handling and reporting to the user

### DIFF
--- a/edbi-bridge.pl
+++ b/edbi-bridge.pl
@@ -16,7 +16,14 @@ sub edbi_connect {
       $dbh->disconnect();
     }
   }
-  our $dbh = DBI->connect($data_source, $username, $auth);
+
+  our $dbh = DBI->connect($data_source, $username, $auth)
+      or die("Could not connect to database:
+Data Source ($data_source)
+User Name: ($username):
+DBI error: ($DBI::errstr)
+");
+
   return $dbh->get_info(18);
 }
 


### PR DESCRIPTION
If the connect info is incorrect, the user currently gets a "can't call method on undef".

This patch will catch the failed connect and report info to the user that's useful to trouble shooting why the connection failed.
