### PR TITLE
Treat no input as "no password" rather than empty string

### DIFF
--- a/edbi-bridge.pl
+++ b/edbi-bridge.pl
@@ -11,6 +11,10 @@ our $sth = undef;
 sub edbi_connect {
   my ($args) = @_;
   my ($data_source,$username,$auth) = @$args;
+
+  # No input _probably_ means "no password" rather than empty string
+  $auth = undef if($auth eq "");
+
   if ($dbh) {
     eval {
       $dbh->disconnect();


### PR DESCRIPTION
Currently, if the login account doesn't have a password and I don't enter a password in the connect information, the emtpy string is sent, and the login fails.

It's way more likely that the correct thing for "no input" is to send undef (i.e. no password).

Further improvements for when $auth eq "" could be to first try undef, and if that fails try with "". Left as an exercise to the first person actually having "" as a password :)
