### PR TITLE
use case-insensitive comparison in column-selector

### DIFF
--- a/edbi.el
+++ b/edbi.el
@@ -159,7 +159,7 @@
     (or
      (loop for c in columns
            for i from 0
-           if (equal c name)
+           if (equal (downcase c) (downcase name))
            return (progn
                     (setq num i)
                     (lambda (xs) (nth num xs))))


### PR DESCRIPTION
This patch is required for edbi to work with my Amazon Redshift cluster.  The table info extraction function doesn't work without it.

Someone did the legwork to investigate how various popular database platforms handle case sensitivity for structure identifiers [here](https://github.com/ontop/ontop/wiki/Case-sensitivity-for-SQL-identifiers).  That writeup indicates that the handling of names that differ only by letter case is undefined on pretty much every database platform, so this patch doesn't make things any worse.
